### PR TITLE
Added ability to put user directory namespace in front of folder path for

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -47,6 +47,11 @@ $rcmail_config['sieverules_folder_encoding'] = null;
 // set to null for default behaviour
 $rcmail_config['sieverules_include_imap_root'] = null;
 
+// include the IMAP default namespace to folder path
+// when creating the rules
+// set to null for not attaching anything
+$rcmail_config['sieverules_folder_default_namespace'] = null;
+
 // ruleset name
 $rcmail_config['sieverules_ruleset_name'] = 'roundcube';
 

--- a/sieverules.php
+++ b/sieverules.php
@@ -1986,9 +1986,10 @@ class sieverules extends rcube_plugin
 					$ifolder = $this->_mbox_encode($ifolder, $rcmail->config->get('sieverules_folder_encoding'));
 
 				if ($rcmail->config->get('sieverules_folder_delimiter', false))
-					rcmail_build_folder_tree($a_mailboxes, str_replace($delimiter, $rcmail->config->get('sieverules_folder_delimiter'), $ifolder), $rcmail->config->get('sieverules_folder_delimiter'));
-				else
-					rcmail_build_folder_tree($a_mailboxes, $ifolder, $delimiter);
+					$ifolder = str_replace($delimiter, $rcmail->config->get('sieverules_folder_delimiter'), $ifolder);
+				if ($rcmail->config->get('sieverules_folder_default_namespace', null))
+					$ifolder = $rcmail->config->get('sieverules_folder_default_namespace') . $ifolder;
+				rcmail_build_folder_tree($a_mailboxes, $ifolder, $delimiter);
 			}
 
 			if ($rcmail->config->get('sieverules_fileinto_options', 0) == 2)


### PR DESCRIPTION
Added ability to put user directory namespace in front of folder path for some imap configurations.

In my configuration server contains "User/" namespace which should be included in sieve file. I could not find any option for this in roundcube nor in sieverules, so I added this to sieverules. Default configuration changes nothing in behaviour of sieverules.
