### PR TITLE
Add vacation-seconds extension period in advanced class so it is shown only when 'advanced options' option is checked

### DIFF
--- a/sieverules.php
+++ b/sieverules.php
@@ -2278,6 +2278,7 @@ class sieverules extends rcube_plugin
 			$period_type_show .= '&nbsp;&nbsp;' . $input_periodtype->show($defaults['periodtype']) . "&nbsp;" . html::label($field_id . '_seconds', rcmail::Q($this->gettext('seconds')));
 			$input_periodtype = new html_hiddenfield(array('id' => 'rcmfd_sievevacperiodtype_'. $rowid, 'name' => '_periodtype[]'));
 
+			$vacs_table->set_row_attribs(array('class' => 'advanced', 'style' => $display['vacadv']));
 			$vacs_table->add(null, '&nbsp;');
 			$vacs_table->add(null, $period_type_show . $input_periodtype->show($defaults['periodtype']));
 			$vacs_table->add(null, '&nbsp;');


### PR DESCRIPTION
This is what is shown currently when vacation-seconds is enabled and you try to add a new filter:

![screen shot 2014-09-11 at 13 24 48](https://cloud.githubusercontent.com/assets/8706/4233155/0f028a02-39a7-11e4-91ad-d10e0155ab11.png)

With this simple patch, this options are added as advanced options too:

![screen shot 2014-09-11 at 13 24 22](https://cloud.githubusercontent.com/assets/8706/4233158/1e61e24a-39a7-11e4-97ad-852f57745cdc.png)
