### PR TITLE
Correct different Ingo syntax

### DIFF
--- a/importFilters/ingo.php.ex
+++ b/importFilters/ingo.php.ex
@@ -36,6 +36,12 @@ class srimport_ingo
 				}
 				elseif (isset($name[$i])) {
 					$token = str_replace(":comparator \"i;ascii-casemap\" ", "", $token);
+					
+                                        // correct ingo syntax "address :all :contains "From|To", just refer to header
+                                        $pregsearch = '/address :all :contains "(From|To)"/';
+                                        $pregrepl = 'header :contains "${1}"';
+                                        $token = preg_replace($pregsearch, $pregrepl, $token);					
+					
 					$content .= $token . "\n";
 					$i++;
 				}


### PR DESCRIPTION
Ingo generated rules having the format "address :all :contains "FromTo"" for address-based-fields (like From/To and such). those rules could not be imported and were skipped in _tokenizeRule() somewhere. instead of changing the regexes there, i added a cleaning replace here. it worked in my case.. ;-)