### PR TITLE
Fix typo in condition check

### DIFF
--- a/lib/Roundcube/rcube_sieve_script.php
+++ b/lib/Roundcube/rcube_sieve_script.php
@@ -937,7 +937,7 @@ class rcube_sieve_script
 		$result = array();
 
 		if ($regex) {
-			if (preg_match('/^"(.*)"$/', $content, $matches));
+			if (preg_match('/^"(.*)"$/', $content, $matches))
 				$content = $matches[1];
 
 			$content = str_replace('\"', '"', $content);


### PR DESCRIPTION
Fixex typo when $content = $matches[1]; was called no mather what happend in previous preg_match