### PR TITLE
Fixed wrong variable name

### DIFF
--- a/lib/Roundcube/rcube_sieve.php
+++ b/lib/Roundcube/rcube_sieve.php
@@ -52,7 +52,7 @@ class rcube_sieve
 		$data = rcube::get_instance()->plugins->exec_hook('sieverules_connect', array(
 			'username' => $username, 'password' => $password, 'host' => $host, 'port' => $port,
 			'auth_type' => $auth_type, 'usetls' => $usetls, 'ruleset' => $ruleset, 'dir' => $dir,
-			'elsif' => $elsif, 'auth_cid' => $auth_cid, 'auth_pw' => $auth_pw, 'socket_options' => $options));
+			'elsif' => $elsif, 'auth_cid' => $auth_cid, 'auth_pw' => $auth_pw, 'socket_options' => $socket_options));
 
 		$username = $data['username'];
 		$password = $data['password'];


### PR DESCRIPTION
Hi,

I believe the $socket_options variable is misspelled when executing the hook. This results in socket options not being used.

This pull requests fixes this

Cheers