### PR TITLE
Avoid endless reloading of settings page in fresh imap accounts

### DIFF
--- a/sieverules.php
+++ b/sieverules.php
@@ -323,8 +323,6 @@ class sieverules extends rcube_plugin
 				// no active ruleset exists, create one with default name and reinitialise
 				$this->current_ruleset = $rcmail->config->get('sieverules_ruleset_name');
 				$this->_startup();
-				$rcmail->overwrite_action('plugin.sieverules.setup');
-				$this->action = 'plugin.sieverules.setup';
 			}
 		}
 


### PR DESCRIPTION
When a new account is created on an imap server it does not have any existing sieve
rules. In order to create a rule a user would go through the roundcube settings and
create one from there. This works fine as long as the configuration of the plugin
contains a valid default_file entry for creating new rulesets.

If that is not the case the unconditional redirect in the init_html function
will trigger over and over again and hence not allow the user to create a ruleset.

Since the code in _startup that detects wether a default rulefile can be found
already does a redirect to the settings location I think the unconditional redirect
in init_html can be safely removed allowing the page to fully load and the user to
manually create a first empty ruleset on the server.